### PR TITLE
docs: add warning about non-reproducible netcdf files

### DIFF
--- a/changelog/271.docs.md
+++ b/changelog/271.docs.md
@@ -1,1 +1,1 @@
-Reintegrate and fix the docs for {py:meth}`xarray.Dataset.pr.add_aggregates_coordinates`, {py:meth}`xarray.DataArray.pr.add_aggregates_coordinates`, and {py:meth}`xarray.Dataset.pr.add_aggregates_variables`.
+Reintegrated and fixed the docs for {py:meth}`xarray.Dataset.pr.add_aggregates_coordinates`, {py:meth}`xarray.DataArray.pr.add_aggregates_coordinates`, and {py:meth}`xarray.Dataset.pr.add_aggregates_variables`.

--- a/changelog/274.docs.md
+++ b/changelog/274.docs.md
@@ -1,0 +1,1 @@
+Added a warning that `netcdf` files are not reproducible.

--- a/docs/source/usage/store_and_load.md
+++ b/docs/source/usage/store_and_load.md
@@ -62,6 +62,18 @@ with tempfile.TemporaryDirectory() as tdname:
     ds.pr.to_netcdf(td / "toy_ds_compressed.nc", encoding=encoding)
 ```
 
+```{caution}
+`netcdf` files are not reproducible.
+
+`netcdf` is a very flexible format, which e.g. supports compression using a range
+of libraries, therefore the exact same `Dataset` can be represented by different
+`netcdf` files on disk. Unfortunately, even if you specify the compression options,
+`netcdf` files additionally contain metadata about all software versions used to
+produce the file. Therefore, if you reproduce a `Dataset` containing the same data
+and metadata and store it to a `netcdf` file, it will generally not create a file
+which is identical.
+```
+
 ## Load from disk
 
 We also provide the function {py:func}`primap2.open_dataset` to load datasets back into memory.


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [x] Description in a `{pr}.thing.md` file in the directory `changelog` added - see [changelog/README.md](https://github.com/pik-primap/primap2/blob/main/changelog/README.md) for details

## Description

Add a paragraph to the docs which warns that netcdf files are not reproducible.

Closes: #184 
