### PR TITLE
remove sum rule from conversion

### DIFF
--- a/primap2/_convert.py
+++ b/primap2/_convert.py
@@ -389,7 +389,7 @@ def factors_categories_to_xarray(
     """Convert dictionary mapping categories to factors into xarray-compatible objects.
 
     Using the xarray objects ensures that in subsequent calculations, everything
-    will cleanly multiply reagardless of the dimensionality of the data.
+    will cleanly multiply regardless of the dimensionality of the data.
 
     Parameters
     ----------
@@ -479,13 +479,9 @@ def derive_weights(
     """
     if operation_type == "input":
         operation_verb = "sum up"
-        trivial_sum_rule = "extensive"
-        nontrivial_sum_rule = "intensive"
         rule_cardinality = rule.cardinality_a
     else:
         operation_verb = "split"
-        trivial_sum_rule = "intensive"
-        nontrivial_sum_rule = "extensive"
         rule_cardinality = rule.cardinality_b
 
     # just one category or trivial sum rule, so no weights required

--- a/primap2/_convert.py
+++ b/primap2/_convert.py
@@ -497,20 +497,15 @@ def derive_weights(
                 category=category,
                 rule=rule,
                 message=f"We need to {operation_verb} multiple categories with"
-                f" sum_rule={nontrivial_sum_rule}, but no {operation_type}_weights are"
+                f" but no {operation_type}_weights are"
                 f" specified.",
             )
         effective_weights = weights.loc[selection]
         # normalize so it is actually a weight, not a factor
         return effective_weights / effective_weights.sum(dim=dim)
 
-    raise WeightingInfoMissing(
-        category=category,
-        rule=rule,
-        message=f"We need to {operation_verb} multiple categories, but the sum_rule is"
-        f" not specified. Rule can only be used if sum_rule={trivial_sum_rule!r} or"
-        f" sum_rule={nontrivial_sum_rule} and {operation_type}_weights are"
-        f" specified.",
+    raise NotImplementedError(
+        f"operation_type must be either input or output. Got {operation_type}"
     )
 
 

--- a/primap2/tests/test_convert.py
+++ b/primap2/tests/test_convert.py
@@ -56,13 +56,11 @@ def test_convert_ipcc(empty_ds: xr.Dataset):
         da.pr.convert(
             dim="category",
             conversion=conversion,
-            sum_rule="extensive",
         )
 
     result = da.pr.convert(
         dim="category",
         conversion=conversion,
-        sum_rule="extensive",
         auxiliary_dimensions={"gas": "source (gas)"},
     )
 
@@ -133,7 +131,6 @@ def test_convert_BURDI(empty_ds: xr.Dataset):
     result = da.pr.convert(
         dim="category",
         conversion=conv,
-        sum_rule="extensive",
         auxiliary_dimensions={"gas": "source (gas)"},
     )
 
@@ -188,7 +185,6 @@ def test_custom_conversion_and_two_custom_categorisations(empty_ds):
     result = da.pr.convert(
         dim="category",
         conversion=conv,
-        sum_rule="extensive",
     )
 
     # category name includes B - the target categorisation


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Description in a `{pr}.thing.md` file in the directory `changelog` added - see [changelog/README.md](https://github.com/pik-primap/primap2/blob/main/changelog/README.md) for details

## Description

Previously the `convert` function supported extensive data (like total emissions in a year subdivided into multiple
sectoral categories) and intensive data (like average per-person emissions in a year subdivided into different territorial entities). We decided that we don't want to support the handling of intensive data, as we don't 
expect this to be a common use case.

This pull request removes the `sum_rule` argument and code and always assumes extensive data. It adds documentation that this is only meant to be used with extensive quantities.

The general plan (Mika): In a first PR remove the `sum_rule`, in a second PR which builds on the first remove the `input_weights` and `output_weights` and raise errors instead if downscaling would be necessary. Then, start work on an actual conversion and add downscaling support as needed. 
