### PR TITLE
one-to-many conversion

### DIFF
--- a/primap2/_convert.py
+++ b/primap2/_convert.py
@@ -186,7 +186,8 @@ class DataArrayConversionAccessor(_accessor_base.BaseDataArrayAccessor):
             # if there is more than one category on the target side
             if len(output_selection[new_dim]) > 1:
                 # TODO this leads to very long category names
-                new_category = "M_" + "_".join(output_selection[new_dim])
+                new_category = create_category_name(rule)
+                # new_category = "A_(" + "_".join(output_selection[new_dim]) + ")"
                 # add newly created category to da
                 new_categories = list(da.indexes["category (IPCC2006)"]) + [new_category]
                 da = da.reindex({"category (IPCC2006)": new_categories}, fill_value=np.nan)
@@ -432,3 +433,12 @@ def prepare_auxiliary_dimensions(
     return {
         climate_categories.cats[name]: auxiliary_dimensions[name] for name in auxiliary_dimensions
     }
+
+
+def create_category_name(rule):
+    factor_to_string = {1: "+", -1: "-"}
+    components = [factor_to_string[i[1]] + i[0].codes[0] for i in rule.factors_categories_b.items()]
+    # remove the first "+" sign in the name (leave a "-" sign in)
+    if components[0][0] == "+":
+        components[0] = components[0][1:]
+    return "A_(" + "".join(components) + ")"

--- a/primap2/_convert.py
+++ b/primap2/_convert.py
@@ -185,10 +185,7 @@ class DataArrayConversionAccessor(_accessor_base.BaseDataArrayAccessor):
 
             # if there is more than one category on the target side
             if len(output_selection[new_dim]) > 1:
-                # TODO this leads to very long category names
                 new_category = create_category_name(rule)
-                # new_category = "A_(" + "_".join(output_selection[new_dim]) + ")"
-                # add newly created category to da
                 new_categories = list(da.indexes["category (IPCC2006)"]) + [new_category]
                 da = da.reindex({"category (IPCC2006)": new_categories}, fill_value=np.nan)
                 new_output_selection = output_selection.copy()
@@ -435,10 +432,22 @@ def prepare_auxiliary_dimensions(
     }
 
 
-def create_category_name(rule):
+def create_category_name(rule: climate_categories.ConversionRule):
+    """
+    Create a category name based on the provided rule.
+
+    Parameters
+    ----------
+    rule : climate_categories.ConversionRule
+        rule to convert between categories from two different categorizations.
+
+    Returns
+    -------
+        The generated category name.
+    """
     factor_to_string = {1: "+", -1: "-"}
     components = [factor_to_string[i[1]] + i[0].codes[0] for i in rule.factors_categories_b.items()]
-    # remove the first "+" sign in the name (leave a "-" sign in)
+    # remove the first "+" sign in the name (leave "-" sign in)
     if components[0][0] == "+":
         components[0] = components[0][1:]
     return "A_(" + "".join(components) + ")"

--- a/primap2/_convert.py
+++ b/primap2/_convert.py
@@ -186,7 +186,7 @@ class DataArrayConversionAccessor(_accessor_base.BaseDataArrayAccessor):
             # if there is more than one category on the target side
             if len(output_selection[new_dim]) > 1:
                 new_category = create_category_name(rule)
-                new_categories = list(da.indexes["category (IPCC2006)"]) + [new_category]
+                new_categories = [*da.indexes["category (IPCC2006)"], new_category]
                 da = da.reindex({"category (IPCC2006)": new_categories}, fill_value=np.nan)
                 new_output_selection = output_selection.copy()
                 new_output_selection[new_dim] = new_category

--- a/primap2/tests/data/BURDI_conversion.csv
+++ b/primap2/tests/data/BURDI_conversion.csv
@@ -23,7 +23,7 @@ BURDI,IPCC2006_PRIMAP,comment
 4.A,3.A.1
 4.B,3.A.2
 4.C,3.C.7
-4.D, M.3.C.45.AG
+4.D, 3.C.45.AG
 4.D + 4.C + 4.E + 4.F + 4.G,3.C
 4.E,3.C.1.c
 4.F,3.C.1.b

--- a/primap2/tests/data/BURDI_conversion.csv
+++ b/primap2/tests/data/BURDI_conversion.csv
@@ -23,7 +23,7 @@ BURDI,IPCC2006_PRIMAP,comment
 4.A,3.A.1
 4.B,3.A.2
 4.C,3.C.7
-4.D, 3.C.45.AG
+4.D, M.3.C.45.AG
 4.D + 4.C + 4.E + 4.F + 4.G,3.C
 4.E,3.C.1.c
 4.F,3.C.1.b

--- a/primap2/tests/data/BURDI_conversion.csv
+++ b/primap2/tests/data/BURDI_conversion.csv
@@ -17,16 +17,19 @@ BURDI,IPCC2006_PRIMAP,comment
 2.C,2.C
 2.F,2.F
 2.G + 2.D, 2.H
+2.G, 2.H.3
 3,2.D
 4,M.AG
 4.A,3.A.1
 4.B,3.A.2
 4.C,3.C.7
+4.D, M.3.C.45.AG
 4.D + 4.C + 4.E + 4.F + 4.G,3.C
 4.E,3.C.1.c
 4.F,3.C.1.b
 4.G,3.C.8
 5,M.LULUCF
+4+5,3
 6,4
 6.A,4.A
 6.B,4.D

--- a/primap2/tests/data/simple_categorisation_b.yaml
+++ b/primap2/tests/data/simple_categorisation_b.yaml
@@ -25,3 +25,12 @@ categories:
     alternative_codes:
       - B
       - CatB
+  3:
+    title: Category 3
+    comment: The third category
+  4:
+    title: Category 4
+    comment: The fourth category
+  5:
+    title: Category 5
+    comment: The fifth category

--- a/primap2/tests/data/test_create_category_name_conversion.csv
+++ b/primap2/tests/data/test_create_category_name_conversion.csv
@@ -1,0 +1,6 @@
+# references: test
+# last_update: 2024-10-14
+A,B,comment
+1,1+2, no comment
+2,-3+4
+3,5-1

--- a/primap2/tests/test_convert.py
+++ b/primap2/tests/test_convert.py
@@ -188,10 +188,14 @@ def test_convert_BURDI(empty_ds: xr.Dataset):
     assert (
         (result.pr.loc[{"category": "M.BIO"}] == 1.0 * primap2.ureg("Gg CO2 / year")).all().item()
     )
-    # map an old category to an unknown new category
     # 4.D -> M.3.C.45.AG
+    # This category is only available on M3C45AG branch in climate categories
+    # test locally with:
+    # `source venv/bin/activate`
+    # `pip install -e ../climate_categories`
+    # Will pass after climate categories release
     assert (
-        (result.pr.loc[{"category": "M.3.C.45.AG"}] == 1.0 * primap2.ureg("Gg CO2 / year"))
+        (result.pr.loc[{"category": "3.C.45.AG"}] == 1.0 * primap2.ureg("Gg CO2 / year"))
         .all()
         .item()
     )
@@ -237,5 +241,5 @@ def test_custom_conversion_and_two_custom_categorisations(empty_ds):
     assert (result.pr.loc[{"category": "2"}] == 2.0 * primap2.ureg("Gg CO2 / year")).all().item()
 
     # check result has 2 categories (input categorisation had 3)
-    # TODO this is ambiguous when order changes
+    # TODO this is ambiguous, order may change
     assert result.shape == (2, 21, 4, 1)

--- a/primap2/tests/test_convert.py
+++ b/primap2/tests/test_convert.py
@@ -68,13 +68,15 @@ def test_convert_ipcc(empty_ds: xr.Dataset):
     # rule 2 + 3 -> 2
     assert (result.pr.loc[{"category": "2"}] == 2.0 * primap2.ureg("Gg CO2 / year")).all().item()
     # rule 1.A.2.f -> 1.A.2.f + 1.A.2.g + 1.A.2.h + 1.A.2.i + 1.A.2.j + 1.A.2.k + 1.A.2.l + 1.A.2.m
-    mcat = "M_1.A.2.f_1.A.2.g_1.A.2.h_1.A.2.i_1.A.2.j_1.A.2.k_1.A.2.l_1.A.2.m"
-    assert (result.pr.loc[{"category": mcat}] == 8.0 * primap2.ureg("Gg CO2 / year")).all().item()
+    autocat = "A_(1.A.2.f+1.A.2.g+1.A.2.h+1.A.2.i+1.A.2.j+1.A.2.k+1.A.2.l+1.A.2.m)"
+    assert (
+        (result.pr.loc[{"category": autocat}] == 8.0 * primap2.ureg("Gg CO2 / year")).all().item()
+    )
     # rule 4.D for N2O only -> 3.C.4 + 3.C.5
-    mcat = "M_3.C.4_3.C.5"
+    autocat = "A_(3.C.4+3.C.5)"
     assert (
         (
-            result.pr.loc[{"category": mcat, "source (gas)": "N2O"}]
+            result.pr.loc[{"category": autocat, "source (gas)": "N2O"}]
             == 2.0 * primap2.ureg("Gg CO2 / year")
         )
         .all()
@@ -84,23 +86,25 @@ def test_convert_ipcc(empty_ds: xr.Dataset):
     all_gases_but_N2O = list(result.indexes["source (gas)"])
     all_gases_but_N2O.remove("N2O")
     assert np.isnan(
-        result.pr.loc[{"category": mcat, "source (gas)": all_gases_but_N2O}].values
+        result.pr.loc[{"category": autocat, "source (gas)": all_gases_but_N2O}].values
     ).all()
     # rule 7 -> 5
     assert (result.pr.loc[{"category": "5"}] == 1.0 * primap2.ureg("Gg CO2 / year")).all().item()
     # rule 2.F.6 -> 2.E + 2.F.6 + 2.G.1 + 2.G.2 + 2.G.4,
     # rule 2.F.6 + 3.D -> 2.E + 2.F.6 + 2.G - ignored because 2.F.G already converted
     # rule 2.G -> 2.H.3 - 1-to-1-conversion
-    mcat = "M_2.E_2.F.6_2.G.1_2.G.2_2.G.4"
-    assert (result.pr.loc[{"category": mcat}] == 5.0 * primap2.ureg("Gg CO2 / year")).all().item()
-    assert "M_2.E_2.F.6_2.G" not in list(result.indexes["category (IPCC2006)"])
+    autocat = "A_(2.E+2.F.6+2.G.1+2.G.2+2.G.4)"
+    assert (
+        (result.pr.loc[{"category": autocat}] == 5.0 * primap2.ureg("Gg CO2 / year")).all().item()
+    )
+    assert "A_(2.E+2.F.6+2.G)" not in list(result.indexes["category (IPCC2006)"])
     assert (
         (result.pr.loc[{"category": "2.H.3"}] == 1.0 * primap2.ureg("Gg CO2 / year")).all().item()
     )
 
 
 # test with new conversion and two existing categorisations
-@pytest.mark.xfail
+# @pytest.mark.xfail
 def test_convert_BURDI(empty_ds: xr.Dataset):
     # make a sample conversion object in climate categories
     filepath = get_test_data_filepath("BURDI_conversion.csv")
@@ -189,16 +193,16 @@ def test_convert_BURDI(empty_ds: xr.Dataset):
         (result.pr.loc[{"category": "M.BIO"}] == 1.0 * primap2.ureg("Gg CO2 / year")).all().item()
     )
     # 4.D -> M.3.C.45.AG
-    # This category is only available on M3C45AG branch in climate categories
+    # TODO This category is only available on M3C45AG branch in climate categories
     # test locally with:
     # `source venv/bin/activate`
     # `pip install -e ../climate_categories`
     # Will pass after climate categories release
-    assert (
-        (result.pr.loc[{"category": "M.3.C.45.AG"}] == 1.0 * primap2.ureg("Gg CO2 / year"))
-        .all()
-        .item()
-    )
+    # assert (
+    #     (result.pr.loc[{"category": "M.3.C.45.AG"}] == 1.0 * primap2.ureg("Gg CO2 / year"))
+    #     .all()
+    #     .item()
+    # )
 
 
 # test with new conversion and new categorisations
@@ -242,4 +246,34 @@ def test_custom_conversion_and_two_custom_categorisations(empty_ds):
 
     # check result has 2 categories (input categorisation had 3)
     # TODO this is ambiguous, order may change
-    assert result.shape == (2, 21, 4, 1)
+    assert result.shape == (5, 21, 4, 1)
+
+
+def test_create_category_name():
+    # make categorisation A from yaml
+    categorisation_a = cc.from_yaml(get_test_data_filepath("simple_categorisation_a.yaml"))
+
+    # make categorisation B from yaml
+    categorisation_b = cc.from_yaml(get_test_data_filepath("simple_categorisation_b.yaml"))
+
+    # categories not part of climate categories so we need to add them manually
+    cats = {
+        "A": categorisation_a,
+        "B": categorisation_b,
+    }
+
+    # make conversion from csv
+    conv = cc.Conversion.from_csv(
+        get_test_data_filepath("test_create_category_name_conversion.csv"), cats=cats
+    )
+
+    # check that first positive category does not have '+' sign
+    autocat = primap2._convert.create_category_name(conv.rules[0])
+    assert autocat == "A_(1+2)"
+
+    # check that first negative category has '-' sign
+    autocat = primap2._convert.create_category_name(conv.rules[1])
+    assert autocat == "A_(-3+4)"
+
+    autocat = primap2._convert.create_category_name(conv.rules[2])
+    assert autocat == "A_(5-1)"

--- a/primap2/tests/test_convert.py
+++ b/primap2/tests/test_convert.py
@@ -104,7 +104,7 @@ def test_convert_ipcc(empty_ds: xr.Dataset):
 
 
 # test with new conversion and two existing categorisations
-# @pytest.mark.xfail
+@pytest.mark.xfail
 def test_convert_BURDI(empty_ds: xr.Dataset):
     # make a sample conversion object in climate categories
     filepath = get_test_data_filepath("BURDI_conversion.csv")
@@ -198,11 +198,11 @@ def test_convert_BURDI(empty_ds: xr.Dataset):
     # `source venv/bin/activate`
     # `pip install -e ../climate_categories`
     # Will pass after climate categories release
-    # assert (
-    #     (result.pr.loc[{"category": "M.3.C.45.AG"}] == 1.0 * primap2.ureg("Gg CO2 / year"))
-    #     .all()
-    #     .item()
-    # )
+    assert (
+        (result.pr.loc[{"category": "M.3.C.45.AG"}] == 1.0 * primap2.ureg("Gg CO2 / year"))
+        .all()
+        .item()
+    )
 
 
 # test with new conversion and new categorisations

--- a/primap2/tests/test_convert.py
+++ b/primap2/tests/test_convert.py
@@ -100,6 +100,7 @@ def test_convert_ipcc(empty_ds: xr.Dataset):
 
 
 # test with new conversion and two existing categorisations
+@pytest.mark.xfail
 def test_convert_BURDI(empty_ds: xr.Dataset):
     # make a sample conversion object in climate categories
     filepath = get_test_data_filepath("BURDI_conversion.csv")
@@ -180,11 +181,19 @@ def test_convert_BURDI(empty_ds: xr.Dataset):
     assert (
         (result.pr.loc[{"category": "3.C.7"}] == 1.0 * primap2.ureg("Gg CO2 / year")).all().item()
     )
-    # 2.E + 2.B = 2.E, 2.E should not be part of new data set
+    # rule 2.E + 2.B -> 2.B
+    # 2.B is part of PRIMAP categories, but cannot be retrieved from conversion
     assert np.isnan(result.pr.loc[{"category": "2.E"}].values).all()
     # cat 14638 in BURDI equals cat M.BIO in IPCC2006_PRIMAP
     assert (
         (result.pr.loc[{"category": "M.BIO"}] == 1.0 * primap2.ureg("Gg CO2 / year")).all().item()
+    )
+    # map an old category to an unknown new category
+    # 4.D -> M.3.C.45.AG
+    assert (
+        (result.pr.loc[{"category": "M.3.C.45.AG"}] == 1.0 * primap2.ureg("Gg CO2 / year"))
+        .all()
+        .item()
     )
 
 

--- a/primap2/tests/test_convert.py
+++ b/primap2/tests/test_convert.py
@@ -195,7 +195,7 @@ def test_convert_BURDI(empty_ds: xr.Dataset):
     # `pip install -e ../climate_categories`
     # Will pass after climate categories release
     assert (
-        (result.pr.loc[{"category": "3.C.45.AG"}] == 1.0 * primap2.ureg("Gg CO2 / year"))
+        (result.pr.loc[{"category": "M.3.C.45.AG"}] == 1.0 * primap2.ureg("Gg CO2 / year"))
         .all()
         .item()
     )

--- a/primap2/tests/test_convert.py
+++ b/primap2/tests/test_convert.py
@@ -16,6 +16,7 @@ def get_test_data_filepath(fname: str):
     return importlib.resources.files("primap2.tests.data").joinpath(fname)
 
 
+@pytest.mark.xfail
 def test_conversion_source_does_not_match_dataset_dimension(empty_ds):
     # make a data set with IPCC1996 categories
     da = empty_ds["CO2"]

--- a/primap2/tests/test_convert.py
+++ b/primap2/tests/test_convert.py
@@ -187,7 +187,7 @@ def test_convert_BURDI(empty_ds: xr.Dataset):
         (result.pr.loc[{"category": "3.C.7"}] == 1.0 * primap2.ureg("Gg CO2 / year")).all().item()
     )
     # rule 2.E + 2.B -> 2.B
-    # 2.B is part of PRIMAP categories, but cannot be retrieved from conversion
+    # 2.E is part of PRIMAP categories, but cannot be retrieved from conversion
     assert np.isnan(result.pr.loc[{"category": "2.E"}].values).all()
     # cat 14638 in BURDI equals cat M.BIO in IPCC2006_PRIMAP
     assert (

--- a/primap2/tests/test_convert.py
+++ b/primap2/tests/test_convert.py
@@ -67,6 +67,9 @@ def test_convert_ipcc(empty_ds: xr.Dataset):
 
     assert (result.pr.loc[{"category": "1"}] == 1.0 * primap2.ureg("Gg CO2 / year")).all().item()
     assert (result.pr.loc[{"category": "2"}] == 2.0 * primap2.ureg("Gg CO2 / year")).all().item()
+    # TODO that name is a bit crazy, naming up for discussion
+    mcat = "M.1.A.2.f_1.A.2.g_1.A.2.h_1.A.2.i_1.A.2.j_1.A.2.k_1.A.2.l_1.A.2.m"
+    assert (result.pr.loc[{"category": mcat}] == 8.0 * primap2.ureg("Gg CO2 / year")).all().item()
 
 
 # test with new conversion and two existing categorisations


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [ ] Description in a `{pr}.thing.md` file in the directory `changelog` added - see [changelog/README.md](https://github.com/pik-primap/primap2/blob/main/changelog/README.md) for details

## Description

Functionality added in this pull request:
- **one-to-many conversion**: Input and output weights are not supported anymore (see PR #282). That means a category (or a group of categories) cannot be split into a group of categories, e.g. `4.B.10 + 4.B.11 + 4.B.12 + 4.B.13 -> 3.A.2.j` works, but `2.C.5 -> 2.C.5 + 2.C.6 + 2.C.7` does not work. When there are several categories on the target side, we now create a new category, e.g. the rule `2.C.5 -> 2.C.5 + 2.C.6 + 2.C.7` would yield a new category `M_2.C.5_2.C.6_2.C.7`. 
- **one-to-one conversion but target category is not part of target categorisation**: If a category on the target side does not exist it we need to create it in the respective categorisation in climate categories. Sometimes categories don't have a matching target category or group of categories, but the information should not be lost in the target categorisation, e.g. `4.D -> M.3.C.45.AG` where `M.3.C.45.AG` is the sum of the agriculture-related emissions of `3.C.4` and `3.C.5`. In this case the user needs to add the category manually to the categorisation in climate categories. We think this will be needed only for `IPCC2006_PRIMAP`. 

**Questions:**
- Does it make sense that a one-to-many conversion creates a new category automatically but an unknown single category needs to be added to climate categories? For example, you could write in your conversion `2.C.5 -> 2.C.5 + 2.C.6 + 2.C.7` and the new category `M_2.C.5_2.C.6_2.C.7` will be created (if all categories are part of your target categorisation). At the same time the `4.D -> M.3.C.45.AG` will raise an error, because `M.3.C.45.AG` is not part of the target categorisation.
- At what point should we move into a real world example (FAO) instead of thinking about theoretical examples. Personally, I would rather have a simple conversion function and then develop it further as we read the FAO data.

**Background (Mika):**
- We have to deal with multiple categories in the target differently. Ideas we had so far:
    - e.g. if you have categories `1.A` and `1.B` on the rhs, automatically add an `A.1.A+1.B` category (name up to debate). 
    - if there is a category which if the sum of the categories on the rhs already, and the rhs categorization is `total_sum`, simply use the existing super-category. E.g. if the rule specifies categories `1.A` and `1.B`, and in the rhs categorization `1` has the children `1.A` and `1.B` only and is `total_sum`, simply use `1` as the rhs category.
    - maybe don't add automatic `A.` categories in the conversion, raise an error instead and the user has to add appropriate `M.` categories to the categorization before the conversion.

- In this PR: start work on an actual conversion and add downscaling support as needed. Maybe we don't need anything automatic, maybe some automation is useful, but that will be much clearer once e.g. the FAO conversion is written and adding also these super-categories by hand is annoying or actually rather pleasant.
