### PR TITLE
fix: add missing dependency on 'build'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ dev =
     sphinx-tippy>=0.4.3
     numpydoc>=1.6
     twine>=5
+    build>=1.2.2
     pre-commit>=3.6
     pytest>=8
     pytest-cov>=4


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Description in a `{pr}.thing.md` file in the directory `changelog` added - see [changelog/README.md](https://github.com/pik-primap/primap2/blob/main/changelog/README.md) for details

## Description

We need the `build` package to build the library for pyPI.
