### PR TITLE
 Ensure NaN values remain NaN during conversion

### DIFF
--- a/changelog/313.fix.md
+++ b/changelog/313.fix.md
@@ -1,0 +1,1 @@
+Fixed conversion of nan values.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -e .
-Sphinx>=4.2
+Sphinx>=4.2,<8.1.3
 myst-nb>=1
 sphinx-book-theme>=1.1
 numpydoc>=1.6

--- a/primap2/_convert.py
+++ b/primap2/_convert.py
@@ -179,7 +179,7 @@ class DataArrayConversionAccessor(_accessor_base.BaseDataArrayAccessor):
                 continue
 
             # the left-hand side of the conversion formula summed up
-            lhs = (input_factors * self._da.loc[input_selection]).sum(dim=dim)
+            lhs = (input_factors * self._da.loc[input_selection]).sum(dim=dim, min_count=1)
             # the right-hand side of the conversion formula split up
             rhs = lhs / output_factors
 
@@ -190,7 +190,7 @@ class DataArrayConversionAccessor(_accessor_base.BaseDataArrayAccessor):
                 da = da.reindex({"category (IPCC2006)": new_categories}, fill_value=np.nan)
                 new_output_selection = output_selection.copy()
                 new_output_selection[new_dim] = new_category
-                da.loc[new_output_selection] = rhs.sum(dim=new_dim)
+                da.loc[new_output_selection] = rhs.sum(dim=new_dim, min_count=1)
                 return output_selection[new_dim], da
             else:
                 da.loc[output_selection] = rhs

--- a/primap2/tests/test_convert.py
+++ b/primap2/tests/test_convert.py
@@ -272,13 +272,11 @@ def test_nan_conversion(empty_ds):
     arr = da.data.copy()
     arr[:] = 1 * primap2.ureg("Gg CO2 / year")
     da.data = arr
-    da_copy = da.copy()
-    da_copy.loc[{"category (A)": "1", "area (ISO3)": "MEX"}] = np.nan * primap2.ureg(
-        "Gg CO2 / year"
-    )
+    # set some values to nan
+    da.loc[{"category (A)": "1", "area (ISO3)": "MEX"}] = np.nan * primap2.ureg("Gg CO2 / year")
 
     # convert to categorisation B
-    result = da_copy.pr.convert(
+    result = da.pr.convert(
         dim="category",
         conversion=conv,
     )

--- a/primap2/tests/test_convert.py
+++ b/primap2/tests/test_convert.py
@@ -250,6 +250,43 @@ def test_custom_conversion_and_two_custom_categorisations(empty_ds):
     assert result.shape == (5, 21, 4, 1)
 
 
+def test_nan_conversion(empty_ds):
+    # make categorisation A from yaml
+    categorisation_a = cc.from_yaml(get_test_data_filepath("simple_categorisation_a.yaml"))
+
+    # make categorisation B from yaml
+    categorisation_b = cc.from_yaml(get_test_data_filepath("simple_categorisation_b.yaml"))
+
+    # categories not part of climate categories so we need to add them manually
+    cats = {
+        "A": categorisation_a,
+        "B": categorisation_b,
+    }
+
+    # make conversion from csv
+    conv = cc.Conversion.from_csv(get_test_data_filepath("simple_conversion.csv"), cats=cats)
+
+    # make a dummy dataset based on A cats
+    da = empty_ds["CO2"]
+    da = da.expand_dims({"category (A)": list(categorisation_a.keys())})
+    arr = da.data.copy()
+    arr[:] = 1 * primap2.ureg("Gg CO2 / year")
+    da.data = arr
+    da_copy = da.copy()
+    da_copy.loc[{"category (A)": "1", "area (ISO3)": "MEX"}] = np.nan * primap2.ureg(
+        "Gg CO2 / year"
+    )
+
+    # convert to categorisation B
+    result = da_copy.pr.convert(
+        dim="category",
+        conversion=conv,
+    )
+
+    # check that the nan value is still nan
+    assert all(np.isnan(result.loc[{"category (B)": "1", "area (ISO3)": "MEX"}].to_numpy()))
+
+
 def test_create_category_name():
     # make categorisation A from yaml
     categorisation_a = cc.from_yaml(get_test_data_filepath("simple_categorisation_a.yaml"))


### PR DESCRIPTION
# Pull request

Johannes found a bug in the convert function. All nan values were converted to zero. With these changes all nan are still nan after the conversion.

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Description in a `{pr}.thing.md` file in the directory `changelog` added - see [changelog/README.md](https://github.com/pik-primap/primap2/blob/main/changelog/README.md) for details

## Description

Please provide a short description what your pull request does.
