### PR TITLE
 Fix the truncation problem when saving to netcdf5 after merging

### DIFF
--- a/changelog/324.fix.md
+++ b/changelog/324.fix.md
@@ -1,0 +1,1 @@
+Drop encoding of data sets when merging or saving to netcfd to avoid truncation of coordinate values

--- a/primap2/_data_format.py
+++ b/primap2/_data_format.py
@@ -250,8 +250,9 @@ class DatasetDataFormatAccessor(_accessor_base.BaseDatasetAccessor):
         ds = self._ds.pint.dequantify()
 
         if encoding is None:
-            # use the zlib compression algorithm and compression level,
-            # which can range from 0 (no compression) to 9 (maximum compression)
+            # use the zlib compression algorithm and compression level 9,
+            # 0 (no compression) - larger files, shorter processing
+            # 9 (maximum compression) - smaller files, longer processing
             compression = dict(zlib=True, complevel=9)
             encoding = {var: compression for var in ds.data_vars}
 

--- a/primap2/_data_format.py
+++ b/primap2/_data_format.py
@@ -240,6 +240,12 @@ class DatasetDataFormatAccessor(_accessor_base.BaseDatasetAccessor):
             ones ``{"compression": "gzip", "compression_opts": 9}``.
             This allows using any compression plugin installed in the HDF5
             library, e.g. LZF.
+
+            Note that we drop encoding information that's already present beforehand
+            and only apply the encoding that is explicitly passed here. For example,
+            if your coordinate has a specified data type in the encoding attribute, it
+            will be dropped and the encoding specified will be applied. If you don't specify
+            encoding, xarray's default encoding will be used.
         """
         ds = self._ds.pint.dequantify()
         if "publication_date" in ds.attrs:
@@ -251,6 +257,8 @@ class DatasetDataFormatAccessor(_accessor_base.BaseDatasetAccessor):
                 and ds[entity].data.dtype == object
             ):
                 ds[entity].data = np.vectorize(lambda x: x.serialize())(ds[entity].data)
+
+        ds = ds.drop_encoding()
         return ds.to_netcdf(
             path=path,
             mode=mode,

--- a/primap2/_data_format.py
+++ b/primap2/_data_format.py
@@ -245,9 +245,16 @@ class DatasetDataFormatAccessor(_accessor_base.BaseDatasetAccessor):
             and only apply the encoding that is explicitly passed here. For example,
             if your coordinate has a specified data type in the encoding attribute, it
             will be dropped and the encoding specified will be applied. If you don't specify
-            encoding, xarray's default encoding will be used.
+            encoding, a default will be defined.
         """
         ds = self._ds.pint.dequantify()
+
+        if encoding is None:
+            # use the zlib compression algorithm and compression level,
+            # which can range from 0 (no compression) to 9 (maximum compression)
+            compression = dict(zlib=True, complevel=9)
+            encoding = {var: compression for var in ds.data_vars}
+
         if "publication_date" in ds.attrs:
             ds.attrs["publication_date"] = ds.attrs["publication_date"].isoformat()
         for entity in ds:

--- a/primap2/_merge.py
+++ b/primap2/_merge.py
@@ -215,6 +215,11 @@ class DatasetMergeAccessor(BaseDatasetAccessor):
 
         ds_start = self._ds
 
+        # Remove the encoding from the dataset
+        # Only the encoding of ds_start is considered in the merge,
+        # so we don't have to remove it from ds_merge
+        ds_start = ds_start.drop_encoding()
+
         with contextlib.suppress(xr.MergeError, ValueError):
             # if there are no conflicts just merge using xr.merge
             return xr.merge(

--- a/primap2/tests/test_merge.py
+++ b/primap2/tests/test_merge.py
@@ -238,11 +238,16 @@ def test_log_formatting_single_date(minimal_ds, caplog):
 
 
 def test_merge_str_encoding(minimal_ds):
+    # start data set
+    minimal_ds["area (ISO3)"].encoding = {"dtype": np.dtype("<U3")}
+
+    # other data set to merge with
     other_ds = minimal_ds.copy(deep=True)
     new_areas = np.array(["COL", "G20", "G7", "UMBRELLA"], dtype="<U8")
     other_ds = other_ds.assign_coords(
         {"area (ISO3)": xr.DataArray(new_areas, coords={"area (ISO3)": new_areas})}
     )
-    minimal_ds["area (ISO3)"].encoding = {"dtype": np.dtype("<U3")}
+    other_ds["area (ISO3)"].encoding = {"dtype": np.dtype("<U8")}
+
     merged_ds = minimal_ds.pr.merge(other_ds)
     assert "dtype" not in merged_ds["area (ISO3)"].encoding

--- a/primap2/tests/test_merge.py
+++ b/primap2/tests/test_merge.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Tests for _merge.py"""
 
+import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
@@ -234,3 +235,14 @@ def test_log_formatting_single_date(minimal_ds, caplog):
         "for time=2000, area (ISO3)=ARG, source=RAND2020:" in caplog.text
     )
     assert "(CO2)\n0.09" in caplog.text
+
+
+def test_merge_str_encoding(minimal_ds):
+    other_ds = minimal_ds.copy(deep=True)
+    new_areas = np.array(["COL", "G20", "G7", "UMBRELLA"], dtype="<U8")
+    other_ds = other_ds.assign_coords(
+        {"area (ISO3)": xr.DataArray(new_areas, coords={"area (ISO3)": new_areas})}
+    )
+    minimal_ds["area (ISO3)"].encoding = {"dtype": np.dtype("<U3")}
+    merged_ds = minimal_ds.pr.merge(other_ds)
+    assert "dtype" not in merged_ds["area (ISO3)"].encoding


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Description in a `{pr}.thing.md` file in the directory `changelog` added - see [changelog/README.md](https://github.com/pik-primap/primap2/blob/main/changelog/README.md) for details

## Description

Fix the truncation problem when saving to netcdf5 after merging.

Closes: #325 

Add a default compression algorithm level and compression level if nothing is specified.
