### PR TITLE
fix: set min_count to 1 in da.pr.sum even if skap_na only defaulted to true instead of bein explicitely set

### DIFF
--- a/changelog/388.breaking.md
+++ b/changelog/388.breaking.md
@@ -1,0 +1,7 @@
+`pr.sum` now uses `min_count=1` by default whenever NA values are skipped, not only when
+`skipna=True` was given explicitly. Summing values which are all NA therefore gives NA
+instead of zero, also when `skipna` is not specified. This affects `da.pr.sum`,
+`ds.pr.sum`, `ds.pr.gas_basket_contents_sum`, and `ds.pr.fill_na_gas_basket_from_contents`,
+which now behave like `ds.pr.add_aggregates_variables` and the downscaling functions, which
+already used `min_count=1`. Pass `min_count=0` explicitly to get the previous behaviour of
+summing only NA values to zero.

--- a/docs/source/usage/skipna.md
+++ b/docs/source/usage/skipna.md
@@ -64,6 +64,21 @@ da.pr.sum(dim="area", skipna=True).pr.to_df()
 da.sum(dim="area (ISO3)").pr.to_df()
 ```
 
+Note that whenever NA values are skipped, {py:meth}`xarray.DataArray.pr.sum` uses
+`min_count=1`, so summing values which are *all* NA gives NA instead of zero. This is the
+case for `skipna=True` as well as for the default, where NA values are skipped for float
+data:
+
+```{code-cell} ipython3
+da.pr.sum(dim="time").pr.to_df()
+```
+
+If you want all-NA sums to be zero instead, pass `min_count=0` explicitly:
+
+```{code-cell} ipython3
+da.pr.sum(dim="time", min_count=0).pr.to_df()
+```
+
 ## Infilling
 
 The same functionality is available for filling in missing information using the

--- a/primap2/_aggregate.py
+++ b/primap2/_aggregate.py
@@ -131,9 +131,11 @@ class DataArrayAggregationAccessor(BaseDataArrayAccessor):
            evaluation dimension ``position`` will skip only those values where all
            values with the same ``position`` are NA.
 
-        ``skipna`` and ``min_count`` work like in the :py:meth:`xarray.DataArray.sum` function.
-        The behaviour
-        of primap1 is reproduced by ``skipna=True, min_count=1``.
+        ``skipna`` and ``min_count`` work like in the :py:meth:`xarray.DataArray.sum`
+        function, with one exception: unless ``skipna=False`` is given, ``min_count``
+        defaults to 1, so that summing only NA values gives NA instead of zero. This
+        reproduces the behaviour of primap1. Pass ``min_count=0`` explicitly to get
+        xarray's behaviour of summing only NA values to zero.
 
         Parameters
         ----------
@@ -146,7 +148,7 @@ class DataArrayAggregationAccessor(BaseDataArrayAccessor):
           arguments can be supplied. Supplying ``reduce_to_dim="dim_1"`` is therefore
           equivalent to giving ``dim=set(da.dims) - {"dim_1"}``, but more legible.
         skipna: bool, optional
-          If ``True``, skip missing values (as marked by NaN). By default, only
+          If ``True`` (default), skip missing values (as marked by NaN). By default, only
           skips missing values for float dtypes; other dtypes either do not
           have a sentinel missing value (int) or ``skipna=True`` has not been
           implemented (``object``, ``datetime64`` or ``timedelta64``).
@@ -158,9 +160,9 @@ class DataArrayAggregationAccessor(BaseDataArrayAccessor):
           result.
         keep_attrs: bool, optional
           Keep the attr metadata (default True).
-        min_count: int (default None, but set to 1 if skipna=True)
+        min_count: int (default None, but set to 1 unless skipna=False)
           The minimal number of non-NA values in a sum that is necessary for a non-NA
-          result. This only has an effect if ``skipna=True``. As an example: you sum data
+          result. This only has an effect if NA values are skipped. As an example: you sum data
           for a region for a certain sector, gas and year. If ``skipna=False``,
           all countries in the region need to have non-NA data for that sector, gas,
           year combination. If ``skipna=True`` and ``min_count=1`` then one country with
@@ -188,7 +190,7 @@ class DataArrayAggregationAccessor(BaseDataArrayAccessor):
             da = self.fill_all_na(dim=skipna_evaluation_dims, value=0)
         else:
             da = self._da
-            if skipna and min_count is None:
+            if skipna is not False and min_count is None:
                 min_count = 1
 
         return da.sum(dim=dim, skipna=skipna, keep_attrs=keep_attrs, min_count=min_count)
@@ -273,9 +275,9 @@ class DataArrayAggregationAccessor(BaseDataArrayAccessor):
             skips missing values for ``float`` dtypes; other dtypes either do not
             have a sentinel missing value (int) or ``skipna=True`` has not been
             implemented (``object``, ``datetime64`` or ``timedelta64``).
-        min_count: int (default None, but set to 1 if skipna=True)
+        min_count: int (default None, but set to 1 unless skipna=False)
             The minimal number of non-NA values in a sum that is necessary for a non-NA
-            result. This only has an effect if ``skipna=True``. As an example: you sum data
+            result. This only has an effect if NA values are skipped. As an example: you sum data
             for a region for a certain sector, gas and year. If ``skipna=False``,
             all countries in the region need to have non-NA data for that sector, gas,
             year combination. If ``skipna=True`` and ``min_count=1`` then one country with
@@ -543,9 +545,11 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
            and summed along the data variables (which will only work if the units of
            the DataArrays are compatible).
 
-        ``skipna`` and ``min_count`` work like in the :py:meth:`xarray.Dataset.sum` function.
-        The behaviour
-        of primap1 is reproduced by ``skipna=True, min_count=1``.
+        ``skipna`` and ``min_count`` work like in the :py:meth:`xarray.Dataset.sum`
+        function, with one exception: unless ``skipna=False`` is given, ``min_count``
+        defaults to 1, so that summing only NA values gives NA instead of zero. This
+        reproduces the behaviour of primap1. Pass ``min_count=0`` explicitly to get
+        xarray's behaviour of summing only NA values to zero.
 
         Parameters
         ----------
@@ -572,9 +576,9 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
           result.
         keep_attrs: bool, optional
           Keep the attr metadata (default True).
-        min_count: int (default None, but set to 1 if skipna=True)
+        min_count: int (default None, but set to 1 unless skipna=False)
           The minimal number of non-NA values in a sum that is necessary for a non-NA
-          result. This only has an effect if ``skipna=True``. As an example: you sum data
+          result. This only has an effect if NA values are skipped. As an example: you sum data
           for a region for a certain sector, gas and year. If ``skipna=False``,
           all countries in the region need to have non-NA data for that sector, gas,
           year combination. If ``skipna=True`` and ``min_count=1`` then one country with
@@ -608,7 +612,7 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
             ds = self.fill_all_na(dim=skipna_evaluation_dims, value=0)
         else:
             ds = self._ds
-            if skipna and min_count is None:
+            if skipna is not False and min_count is None:
                 min_count = 1
 
         if dim is not None and "entity" in dim:
@@ -663,9 +667,9 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
           If all values along the specified dimensions are NA, the values are skipped,
           other NA values are not skipped and will lead to NA in the corresponding
           result.
-        min_count: int (default None, but set to 1 if skipna=True)
+        min_count: int (default None, but set to 1 unless skipna=False)
           The minimal number of non-NA values in a sum that is necessary for a non-NA
-          result. This only has an effect if ``skipna=True``. As an example: you sum data
+          result. This only has an effect if NA values are skipped. As an example: you sum data
           for a region for a certain sector, gas and year. If ``skipna=False``,
           all countries in the region need to have non-NA data for that sector, gas,
           year combination. If ``skipna=True`` and ``min_count=1`` then one country with
@@ -751,9 +755,9 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
           If all values along the specified dimensions are NA, the values are skipped,
           other NA values are not skipped and will lead to NA in the corresponding
           result.
-        min_count: int (default None, but set to 1 if skipna=True)
+        min_count: int (default None, but set to 1 unless skipna=False)
           The minimal number of non-NA values in a sum that is necessary for a non-NA
-          result. This only has an effect if ``skipna=True``. As an example: you sum data
+          result. This only has an effect if NA values are skipped. As an example: you sum data
           for a region for a certain sector, gas and year. If ``skipna=False``,
           all countries in the region need to have non-NA data for that sector, gas,
           year combination. If ``skipna=True`` and ``min_count=1`` then one country with
@@ -836,9 +840,9 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
             skips missing values for float dtypes; other dtypes either do not
             have a sentinel missing value (int) or ``skipna=True`` has not been
             implemented (``object``, ``datetime64`` or ``timedelta64``).
-        min_count: int (default None, but set to 1 if skipna=True)
+        min_count: int (default None, but set to 1 unless skipna=False)
             The minimal number of non-NA values in a sum that is necessary for a non-NA
-            result. This only has an effect if ``skipna=True``. As an example: you sum data
+            result. This only has an effect if NA values are skipped. As an example: you sum data
             for a region for a certain sector, gas and year. If ``skipna=False``,
             all countries in the region need to have non-NA data for that sector, gas,
             year combination. If ``skipna=True`` and ``min_count=1`` then one country with
@@ -914,9 +918,9 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
             skips missing values for float dtypes; other dtypes either do not
             have a sentinel missing value (int) or ``skipna=True`` has not been
             implemented (``object``, ``datetime64`` or ``timedelta64``).
-        min_count: int (default None, but set to 1 if skipna=True)
+        min_count: int (default None, but set to 1 unless skipna=False)
             The minimal number of non-NA values in a sum that is necessary for a non-NA
-            result. This only has an effect if ``skipna=True``. As an example: you sum data
+            result. This only has an effect if NA values are skipped. As an example: you sum data
             for a region for a certain sector, gas and year. If ``skipna=False``,
             all countries in the region need to have non-NA data for that sector, gas,
             year combination. If ``skipna=True`` and ``min_count=1`` then one country with

--- a/primap2/tests/test_aggregate.py
+++ b/primap2/tests/test_aggregate.py
@@ -141,6 +141,43 @@ class TestSum:
         dssdef = ds.pr.sum(dim="b", skipna=True)
         xr.testing.assert_identical(dssdef, dss1_expected)
 
+    def test_skipna_default(self):
+        """Without an explicit ``skipna``, summing only NA values has to give NA, not 0.
+
+        ``min_count=1`` is the default whenever NA values are skipped, which includes
+        the default ``skipna=None`` (which skips NA values for float dtypes).
+        """
+        coords = [("a", [1, 2]), ("b", [1, 2]), ("c", [1, 2, 3])]
+        da = xr.DataArray(
+            data=[
+                [[np.nan, np.nan, np.nan], [np.nan, 1, 2]],
+                [[np.nan, np.nan, np.nan], [np.nan, 1, 2]],
+            ],
+            coords=coords,
+        )
+        expected = xr.DataArray(
+            data=[[np.nan, 1, 2], [np.nan, 1, 2]], coords=[coords[0], coords[2]]
+        )
+
+        assert np.allclose(da.pr.sum(dim="b"), expected, equal_nan=True)
+        assert np.allclose(da.pr.sum(reduce_to_dim=["a", "c"]), expected, equal_nan=True)
+
+        ds = xr.Dataset({"1": da, "2": da.copy()})
+        ds_expected = xr.Dataset({"1": expected, "2": expected})
+        xr.testing.assert_identical(ds.pr.sum(dim="b"), ds_expected)
+
+        # summing along the entity dimension has to preserve NA as well
+        entity_expected = expected + expected
+        assert np.allclose(ds.pr.sum(dim=["b", "entity"]), entity_expected, equal_nan=True)
+
+        # the old behaviour of treating all-NA sums as 0 is still available explicitly
+        zero_expected = xr.DataArray(data=[[0, 1, 2], [0, 1, 2]], coords=[coords[0], coords[2]])
+        assert np.allclose(da.pr.sum(dim="b", min_count=0), zero_expected, equal_nan=True)
+        xr.testing.assert_identical(
+            ds.pr.sum(dim="b", min_count=0),
+            xr.Dataset({"1": zero_expected, "2": zero_expected}),
+        )
+
     def test_inhomogeneous_regression(self, opulent_ds: xr.Dataset):
         ds = opulent_ds
         dss = ds.pr.loc[{"category": ["1", "2", "3", "4", "5"]}].pr.sum("category")
@@ -269,6 +306,36 @@ class TestGasBasket:
         expected.loc[{"area (ISO3)": "COL"}] = (1 + self.sf6) * ureg("Gg CO2 / year")
         assert_equal(summed, expected)
 
+    @pytest.fixture
+    def all_nan_ds(self, partly_nan_ds):
+        """Like ``partly_nan_ds``, but for MEX all basket contents are NaN."""
+        for gas in ("CO2", "SF6", "CH4"):
+            partly_nan_ds[gas].loc[{"area (ISO3)": "MEX"}] = np.nan * ureg(f"Gg {gas} / year")
+        return partly_nan_ds
+
+    def test_contents_sum_default_all_na(self, all_nan_ds):
+        """Without an explicit ``skipna``, a basket with only NA contents has to be NA."""
+        summed = all_nan_ds.pr.gas_basket_contents_sum(
+            basket="KYOTOGHG (AR4GWP100)",
+            basket_contents=["CO2", "SF6", "CH4"],
+        )
+        expected = all_nan_ds["KYOTOGHG (AR4GWP100)"].copy()
+        expected[:] = (1 + self.sf6 + self.ch4) * ureg("Gg CO2 / year")
+        # single NaN counted as 0
+        expected.loc[{"area (ISO3)": "COL"}] = (1 + self.sf6) * ureg("Gg CO2 / year")
+        # all contents NaN, so the sum is NaN and not 0
+        expected.loc[{"area (ISO3)": "MEX"}] = np.nan * ureg("Gg CO2 / year")
+        assert_equal(summed, expected, equal_nan=True)
+
+        # the old behaviour of treating all-NA sums as 0 is still available explicitly
+        summed_zero = all_nan_ds.pr.gas_basket_contents_sum(
+            basket="KYOTOGHG (AR4GWP100)",
+            basket_contents=["CO2", "SF6", "CH4"],
+            min_count=0,
+        )
+        expected.loc[{"area (ISO3)": "MEX"}] = 0 * ureg("Gg CO2 / year")
+        assert_equal(summed_zero, expected, equal_nan=True)
+
     def test_contents_sum_skipna_evaluation_dims(self, partly_nan_ds):
         partly_nan_ds["CH4"].loc[{"area (ISO3)": "ARG", "time": "2012"}] = np.nan * ureg(
             "Gg CH4 / year"
@@ -357,6 +424,33 @@ class TestGasBasket:
                 sel={"area (ISO3)": "BOL"},
                 skipna_evaluation_dims=("time",),
             )
+
+    def test_fill_na_from_contents_default_all_na(self, all_nan_ds):
+        """Without an explicit ``skipna``, NA baskets with only NA contents stay NA."""
+        all_nan_ds["KYOTOGHG (AR4GWP100)"][:] = np.nan * ureg("Gg CO2 / year")
+        filled = all_nan_ds.pr.fill_na_gas_basket_from_contents(
+            basket="KYOTOGHG (AR4GWP100)",
+            basket_contents=["CO2", "SF6", "CH4"],
+        )
+        expected = all_nan_ds["KYOTOGHG (AR4GWP100)"].copy()
+        expected[:] = (1 + self.sf6 + self.ch4) * ureg("Gg CO2 / year")
+        expected.loc[{"area (ISO3)": "COL"}] = (1 + self.sf6) * ureg("Gg CO2 / year")
+        # all contents NaN, so nothing to fill with
+        expected.loc[{"area (ISO3)": "MEX"}] = np.nan * ureg("Gg CO2 / year")
+        assert_equal(filled, expected, equal_nan=True)
+
+    def test_add_aggregates_variables_default_all_na(self, all_nan_ds):
+        """A basket aggregated from only NA contents has to be NA, not 0."""
+        aggregated = all_nan_ds.pr.add_aggregates_variables(
+            gas_baskets={"KYOTOGHG (AR6GWP100)": ["CO2", "SF6", "CH4"]},
+        )
+        expected = all_nan_ds["KYOTOGHG (AR4GWP100)"].copy()
+        expected[:] = (1 + self.sf6_ar6 + self.ch4_ar6) * ureg("Gg CO2 / year")
+        expected.loc[{"area (ISO3)": "COL"}] = (1 + self.sf6_ar6) * ureg("Gg CO2 / year")
+        expected.loc[{"area (ISO3)": "MEX"}] = np.nan * ureg("Gg CO2 / year")
+        expected.name = "KYOTOGHG (AR6GWP100)"
+        expected.attrs = {"gwp_context": "AR6GWP100", "entity": "KYOTOGHG"}
+        assert_equal(aggregated["KYOTOGHG (AR6GWP100)"], expected, equal_nan=True)
 
     def test_fill_na_from_contents_skipna(self, partly_filled_ds):
         filled = partly_filled_ds.pr.fill_na_gas_basket_from_contents(


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Description in a `{pr}.thing.md` file in the directory `changelog` added - see [changelog/README.md](https://github.com/pik-primap/primap2/blob/main/changelog/README.md) for details

## Description

The main part of https://github.com/primap-community/primap2/issues/132 was already implemented in version 0.9.8, but it was inconsistent if `skip_na` only defaulted to true (ie. was set to `None`). Fixed this to be more consistent
